### PR TITLE
Experimental support for n-way sum types.

### DIFF
--- a/FsPickler/Combinators.fs
+++ b/FsPickler/Combinators.fs
@@ -124,6 +124,7 @@
             /// See `product` and `field` combinators.
             module ProductInternals =
 
+                /// Internal type for type-checking intermediate values.
                 type Part<'R,'X,'Z> =
                     private
                     | P of ('R -> 'Z) * ('X -> 'Z -> 'R) * Pickler<'Z>
@@ -134,13 +135,16 @@
                 let private finish () =
                     pp ignore (fun r () -> r) unit
 
+                /// Internal type for type-checking intermediate values.
                 type Wrap<'T> =
                     internal
                     | W of 'T
 
+                    /// Defines an extra field.
                     static member ( ^+ ) (W f, x) =
                         f x
 
+                    /// Defines the last field.
                     static member ( ^. ) (W f, W x) =
                         f (x (finish ()))
 
@@ -175,13 +179,106 @@
             ///        }
             ///
             ///    let personPickler =
-            ///        product makePerson
-            ///        ^+ field (fun p -> p.Name) Pickler.string
-            ///        ^+ field (fun p -> p.Age) Pickler.int
-            ///        ^. field (fun p -> p.Address) Pickler.string
+            ///        Pickler.product makePerson
+            ///        ^+ Pickler.field (fun p -> p.Name) Pickler.string
+            ///        ^+ Pickler.field (fun p -> p.Age) Pickler.int
+            ///        ^. Pickler.field (fun p -> p.Address) Pickler.string
+            ///
+            /// The implementation is not currently efficient, though it
+            /// may improve in the future.
             let product f =
                 ProductInternals.W (ProductInternals.defProduct f)
 
             /// See `product`.
             let field f p =
                 ProductInternals.W (ProductInternals.defField f p)
+
+            /// Experimental support for n-way sum types such as unions.
+            /// See `sum`.
+            module SumInternals =
+
+                /// Internal type for type-checking intermediate values.
+                type Part<'U,'T,'X,'Y> =
+                    private
+                    | P of Pickler<'X> * ('X -> 'U) * (('X -> 'Y) -> ('T -> 'Y))
+
+                let private defP p f g =
+                    P (p, f, g)
+
+                let private defLastCase inj p =
+                    defP p inj (fun h t -> t h)
+
+                let private defNextCase inj p (P (tr, xu, f)) =
+                    defP (choice2 p tr)
+                        (function
+                            | Choice1Of2 x -> inj x
+                            | Choice2Of2 x -> xu x)
+                        (fun g h ->
+                            f (fun x -> g (Choice2Of2 x))
+                                (h (fun x -> g (Choice1Of2 x))))
+
+                let private defSum ev (P (tr, xu, f)) =
+                    wrap xu (fun u -> f (fun x -> x) (ev u)) tr
+
+                /// Internal type for type-checking intermediate values.
+                type Case<'T1,'T2> =
+                    internal
+                    | C of 'T1 * 'T2
+
+                    /// Adds a case.
+                    static member ( ^+ ) (C (i1, p1), W x) =
+                        W (defNextCase i1 p1 x)
+
+                    /// Adds the last case.
+                    static member ( ^. ) (C (i1, p1), C (i2, p2)) =
+                        W (defNextCase i1 p1 (defLastCase i2 p2))
+
+                /// Internal type for type-checking intermediate values.
+                and Wrap<'T> =
+                    internal
+                    | W of 'T
+
+                    /// Adds a case.
+                    static member ( ^+ ) (W f, W x) =
+                        f x
+
+                    /// Adds the last case.
+                    static member ( ^. ) (W f, C (inj, p)) =
+                        f (defLastCase inj p)
+
+                let internal makeCase inj p =
+                    C (inj, p)
+
+                let internal makeSum f =
+                    W (defSum f)
+
+            /// Starts defining a pickler for an n-ary sum type, such as
+            /// a union type. For example:
+            ///
+            ///    type UnionT =
+            ///        | Case1
+            ///        | Case2 of int
+            ///        | Case3 of string * int
+            ///
+            ///    let unionTPickler =
+            ///        Pickler.sum (fun x k1 k2 k3 ->
+            ///            match x with
+            ///            | Case1 -> k1 ()
+            ///            | Case2 x -> k2 x
+            ///            | Case3 (x, y) -> k3 (x, y))
+            ///        ^+ Pickler.variant Case1
+            ///        ^+ Pickler.case Case2 Pickler.int
+            ///        ^. Pickler.case Case3 (Pickler.pair Pickler.string Pickler.int)
+            ///
+            /// Note that the implementation is not currently efficient,
+            /// though it may improve in the future.
+            let sum f =
+                SumInternals.makeSum f
+
+            /// See `sum`.
+            let case inj p =
+                SumInternals.makeCase inj p
+
+            /// Useful for union cases without arguments.
+            let variant v =
+                case (fun () -> v) unit


### PR DESCRIPTION
Added sum types to the mix. Again, performance is dismal, but I am kind of happy I figured the types out.

I also finally have Coq code for these combinators without any undefined holes. As you see, they are very general, work in terms of binary `pair`, `choice` and `wrap`. My hope is that the Coq definition will help to:
1. As we give it more structure to assume on `Pickler<'T>`, we can partially evaluate the definitions with that, automatically performing specialization.
2. Semi-automatically unroll the definitions and compute efficient programs for the 2-3-4-5 cases.
3. Figure out how to do rewriting simplifications. 

I can share the Coq code if you are interested. Thanks.
