### PR TITLE
Build for both net40 and net45

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.vssscc
 $tf*/
+build/
+packages/

--- a/FsPickler.Tests/FsPickler.Tests.fsproj
+++ b/FsPickler.Tests/FsPickler.Tests.fsproj
@@ -11,6 +11,7 @@
     <AssemblyName>FsPickler.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>FsPickler.Tests</Name>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,7 +43,19 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="Utils.fs" />
     <Compile Include="Serializers.fs" />
@@ -63,14 +76,14 @@
       <HintPath>..\packages\FSharp.Charting.0.90.5\lib\net40\FSharp.Charting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FsUnit.NUnit">
       <HintPath>..\packages\FsUnit.1.2.1.0\Lib\Net40\FsUnit.NUnit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/FsPickler.sln
+++ b/FsPickler.sln
@@ -1,9 +1,22 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio Express 2013 for Web
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsPickler", "FsPickler\FsPickler.fsproj", "{3AD987BF-F0FA-40BD-9DAE-4AF3A5FE9CC7}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FsPickler.Tests", "FsPickler.Tests\FsPickler.Tests.fsproj", "{BA81B7DB-5759-433E-A6BF-5CDA81C3BDAA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{87846678-C0AD-48CD-8D7D-4224116EEB73}"
+	ProjectSection(SolutionItems) = preProject
+		build.cmd = build.cmd
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{AE27DDEA-35D1-454B-B87F-45E3C4495910}"
+	ProjectSection(SolutionItems) = preProject
+		tools\FsPickler.nuspec = tools\FsPickler.nuspec
+		tools\FsPickler.proj = tools\FsPickler.proj
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/FsPickler/FsPickler.fsproj
+++ b/FsPickler/FsPickler.fsproj
@@ -9,34 +9,74 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FsPickler</RootNamespace>
     <AssemblyName>FsPickler</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>FsPickler</Name>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;OPTIMIZE_FSHARP;EMIT_IL</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\FsPickler.XML</DocumentationFile>
-    <OtherFlags>
-    </OtherFlags>
+    <DocumentationFile>bin\Debug\FsPickler.xml</DocumentationFile>
+    <OtherFlags></OtherFlags>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;PROTECT_STACK_OVERFLOWS;OPTIMIZE_FSHARP;SERIALIZE_STRONG_NAMES;BUILD_STRONG_NAME;EMIT_IL</DefineConstants>
+    <DefineConstants>TRACE;PROTECT_STACK_OVERFLOWS;OPTIMIZE_FSHARP;SERIALIZE_STRONG_NAMES;EMIT_IL</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\FsPickler.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\FsPickler.xml</DocumentationFile>
+    <KeyOriginatorFile Condition="Exists('../../Lib/key.snk')">../../Lib/key.snk</KeyOriginatorFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Rel40|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>..\build\net40</OutputPath>
+    <DefineConstants>TRACE;PROTECT_STACK_OVERFLOWS;OPTIMIZE_FSHARP;SERIALIZE_STRONG_NAMES;EMIT_IL;NET40</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>$(OutputPath)\$(Name).xml</DocumentationFile>
+    <KeyOriginatorFile Condition="Exists('../../Lib/key.snk')">../../Lib/key.snk</KeyOriginatorFile>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Rel45|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>..\build\net45</OutputPath>
+    <DefineConstants>TRACE;PROTECT_STACK_OVERFLOWS;OPTIMIZE_FSHARP;SERIALIZE_STRONG_NAMES;EMIT_IL</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>$(OutputPath)\$(Name).xml</DocumentationFile>
+    <KeyOriginatorFile Condition="Exists('../../Lib/key.snk')">../../Lib/key.snk</KeyOriginatorFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="assemblyInfo.fs" />
     <Compile Include="Utils.fs" />
@@ -64,19 +104,10 @@
     <None Include="Test.fsx" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/FsPickler/Pickler.fs
+++ b/FsPickler/Pickler.fs
@@ -259,7 +259,7 @@
         // using UTF8 gives an observed performance improvement ~200%
         let encoding = defaultArg encoding Encoding.UTF8
 
-        let bw = new BinaryWriter(stream, encoding, defaultArg leaveOpen true)
+        let bw = BinaryWriter.Create(stream, encoding, defaultArg leaveOpen true)
         let sc = match streamingContext with None -> new StreamingContext() | Some sc -> sc
         let mutable idGen = new ObjectIDGenerator()
         let objStack = new Stack<int64> ()
@@ -427,7 +427,7 @@
         // using UTF8 gives an observed performance improvement ~200%
         let encoding = defaultArg encoding Encoding.UTF8
 
-        let br = new BinaryReader(stream, encoding, defaultArg leaveOpen true)
+        let br = BinaryReader.Create(stream, encoding, defaultArg leaveOpen true)
         let sc = match streamingContext with None -> new StreamingContext() | Some sc -> sc
         let objCache = new Dictionary<int64, obj> ()
         let fixupIndex = new Dictionary<int64, Type * obj> ()

--- a/FsPickler/Utils.fs
+++ b/FsPickler/Utils.fs
@@ -453,3 +453,84 @@
                 gatherFields t
                 |> Seq.distinct
                 |> Seq.forall (fun f -> isOfFixedSize f.FieldType)
+
+    [<AutoOpen>]
+    module internal Extensions =
+        open System
+        open System.IO
+        open System.Reflection
+        open System.Text
+
+        #if NET40
+
+        type AssemblyName with
+            member this.CultureName = this.CultureInfo.Name
+
+        [<Sealed>]
+        type private NonClosingStreamWrapper(s: Stream) =
+            inherit Stream()
+
+            let mutable closed = false
+            let ns () = raise (NotSupportedException())
+
+            let cc () =
+                if closed then
+                    failwith "NonClosingStreamWrapper has been closed or disposed"
+
+            override w.BeginRead(a, b, c, d, e) = cc (); s.BeginRead(a, b, c, d, e)
+            override w.BeginWrite(a, b, c, d, e) = cc (); s.BeginWrite(a, b, c, d, e)
+
+            override w.Close() =
+                if not closed then
+                    s.Flush()
+                    closed <- true
+
+            override w.CreateObjRef(t) = ns ()
+            override w.EndRead(x) = cc (); s.EndRead(x)
+            override w.EndWrite(x) = cc (); s.EndWrite(x)
+            override w.Flush() = cc (); s.Flush()
+            override w.InitializeLifetimeService() = ns ()
+            override w.Read(a, b, c) = cc (); s.Read(a, b, c)
+            override w.ReadByte() = cc (); s.ReadByte()
+            override w.Seek(a, b) = cc (); s.Seek(a, b)
+            override w.SetLength(a) = cc (); s.SetLength(a)
+            override w.Write(a, b, c) = cc (); s.Write(a, b, c)
+            override w.WriteByte(a) = cc (); s.WriteByte(a)
+            override w.CanRead = if closed then false else s.CanRead
+            override w.CanSeek = if closed then false else s.CanSeek
+            override w.CanTimeout = if closed then false else s.CanTimeout
+            override w.CanWrite = if closed then false else s.CanWrite
+            override w.Length = cc (); s.Length
+
+            override w.Position
+                with get () = cc (); s.Position
+                and set x = cc (); s.Position <- x
+
+            override w.ReadTimeout = cc (); s.ReadTimeout
+            override w.WriteTimeout = cc (); s.WriteTimeout
+
+        type BinaryWriter with
+            static member Create(output: Stream, encoding: Encoding, leaveOpen: bool) =
+                if leaveOpen then
+                    new BinaryWriter(new NonClosingStreamWrapper(output), encoding)
+                else
+                    new BinaryWriter(output, encoding)
+
+        type BinaryReader with
+            static member Create(output: Stream, encoding: Encoding, leaveOpen: bool) =
+                if leaveOpen then
+                    new BinaryReader(new NonClosingStreamWrapper(output), encoding)
+                else
+                    new BinaryReader(output, encoding)
+
+        #else
+
+        type BinaryWriter with
+            static member Create(output: Stream, encoding: Encoding, leaveOpen: bool) =
+                new BinaryWriter(output, encoding, leaveOpen)
+
+        type BinaryReader with
+            static member Create(output: Stream, encoding: Encoding, leaveOpen: bool) =
+                new BinaryReader(output, encoding, leaveOpen)
+
+        #endif

--- a/FsPickler/assemblyInfo.fs
+++ b/FsPickler/assemblyInfo.fs
@@ -2,14 +2,9 @@
 
     open System.Reflection
 
-#if BUILD_STRONG_NAME
-    [<assembly:AssemblyKeyFile("../../Lib/key.snk")>]
-#endif
     [<assembly:AssemblyVersion("0.8.5.*")>]
-    do()
-
+    do ()
 
     module internal Config =
-        
         [<Literal>]
         let optimizeForLittleEndian = true

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,5 @@
+@ECHO OFF
+setlocal
+set PATH=%PATH%;%ProgramFiles(X86)%\MSBuild\12.0\Bin
+MSBuild.exe tools/FsPickler.proj
+tools\NuGet.exe pack tools\FsPickler.nuspec -outputDirectory build

--- a/tools/FsPickler.nuspec
+++ b/tools/FsPickler.nuspec
@@ -9,7 +9,7 @@
         <copyright>Eirik Tsarpalis</copyright>
         <projectUrl>https://github.com/eiriktsarpalis/FsPickler/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<iconUrl>http://www.m-brace.net/media/pickler.jpg</iconUrl>
+        <iconUrl>http://www.m-brace.net/media/pickler.jpg</iconUrl>
         <licenseUrl>https://github.com/eiriktsarpalis/FsPickler/blob/master/License.md</licenseUrl>
         <description>* Based on the notion of pickler combinators.
 * Provides an automated, strongly typed, pickler generation framework.
@@ -26,4 +26,10 @@ For more information, see https://github.com/eiriktsarpalis/FsPickler</descripti
         <releaseNotes>* Minor corrections.</releaseNotes>
         <tags>F#, serializer, pickler combinators</tags>
     </metadata>
+   <files>
+     <file src="..\build\net40\FsPickler.dll" target="lib\net40" />
+     <file src="..\build\net40\FsPickler.xml" target="lib\net40" />
+     <file src="..\build\net45\FsPickler.dll" target="lib\net45" />
+     <file src="..\build\net45\FsPickler.xml" target="lib\net45" />
+   </files>
 </package>

--- a/tools/FsPickler.proj
+++ b/tools/FsPickler.proj
@@ -1,0 +1,14 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Target Name="Build">
+    <MSBuild Projects="../FsPickler/FsPickler.fsproj" Properties="Configuration=Rel40" />
+    <MSBuild Projects="../FsPickler/FsPickler.fsproj" Properties="Configuration=Rel45" />
+  </Target>
+  <Target Name="Clean">
+    <MSBuild Projects="../FsPickler/FsPickler.fsproj" Properties="Configuration=Rel40" Targets="Clean" />
+    <MSBuild Projects="../FsPickler/FsPickler.fsproj" Properties="Configuration=Rel45" Targets="Clean" />
+    <ItemGroup>
+      <BuildFiles Include="../build/**/*.*" />
+    </ItemGroup>
+    <Delete Files="@(BuildFiles)" />
+  </Target>
+</Project>


### PR DESCRIPTION
Would be very useful to have net40 build together with net45 build (or else just default to net40). I tried to downgrade, there are a just a few places where net45 functionality is used. I tried to fix it in this PR, and added a "build.cmd" that builds a package with both net40 and net45 folders populated with appropriate `FsPickler.dll`.
